### PR TITLE
Task #34 - usa breakdown

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -9,4 +9,7 @@ export const GLOBALS = {
     US_KEY: 'US',
     TOGGLE_BTN_SHOW_MORE: 'Show Details',
     TOGGLE_BTN_HIDE: 'Hide Details',
+    DROPDOWN_MAPPING: {
+        US: 'United States',
+    },
 };

--- a/src/globals.js
+++ b/src/globals.js
@@ -1,0 +1,12 @@
+export const GLOBALS = {
+    ALL_COUNTRIES: 'Overall Worldwide Totals',
+    LANDSCAPE_WIDTH: 900,
+    LANDSCAPE_HEIGHT: 500,
+    PORTRAIT_WIDTH: 450,
+    PORTRAIT_HEIGHT: 500,
+    THRESHOLD: 5000,
+    US_THRESHOLD: 1000,
+    US_KEY: 'US',
+    TOGGLE_BTN_SHOW_MORE: 'Show Details',
+    TOGGLE_BTN_HIDE: 'Hide Details',
+};

--- a/src/index.html
+++ b/src/index.html
@@ -96,6 +96,11 @@
                     geography.
                 </p>
 
+                <p>
+                    All reporting is at the country level with the exception of
+                    the United States contains state-level detail.
+                </p>
+
                 <button id="notes-toggle-btn">Toggle details</button>
                 <div id="full-methodology-notes" class="hidden">
                     <h3>Data sources</h3>

--- a/src/index.html
+++ b/src/index.html
@@ -98,7 +98,7 @@
 
                 <p>
                     All reporting is at the country level with the exception of
-                    the United States contains state-level detail.
+                    the United States which contains state-level detail.
                 </p>
 
                 <button id="notes-toggle-btn">Toggle details</button>

--- a/src/index.html
+++ b/src/index.html
@@ -131,8 +131,14 @@
                     <h3>Data Grouping</h3>
                     <p>
                         All countries that have reported less than 5,000 cases
-                        have been grouped in to one category labeled as "< 5,00
+                        have been grouped in to one category labeled as "< 5,000
                         cases" to reduce visual noise in the visualization.
+                    </p>
+                    <p>
+                        The United States is further broken down by state and
+                        uses a different threshold for visualization purposes.
+                        The label for the grouped category follows the same
+                        naming convention as with the all countries grouping.
                     </p>
 
                     <h3>Total Confirmed Metric</h3>

--- a/src/index.js
+++ b/src/index.js
@@ -4,17 +4,7 @@ import * as d3 from 'd3';
 import { sankeyLinkHorizontal, sankey as sankeyInstance } from 'd3-sankey';
 import { parseWorld } from './process-data';
 import rawData from './raw-data.json';
-
-const GLOBALS = {
-    ALL_COUNTRIES: 'Overall Worldwide Totals',
-    LANDSCAPE_WIDTH: 900,
-    LANDSCAPE_HEIGHT: 500,
-    PORTRAIT_WIDTH: 450,
-    PORTRAIT_HEIGHT: 500,
-    THRESHOLD: 5000,
-    TOGGLE_BTN_SHOW_MORE: 'Show Details',
-    TOGGLE_BTN_HIDE: 'Hide Details',
-};
+import { GLOBALS } from './globals';
 
 const dataURL = 'https://pomber.github.io/covid19/timeseries.json';
 const color = '#ccc';

--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,15 @@ import { GLOBALS } from './globals';
 
 const dataURL = 'https://pomber.github.io/covid19/timeseries.json';
 const color = '#ccc';
+let currentThreshold = GLOBALS.THRESHOLD;
 
 const init = () => {
     // retrieve data
     const { sankey: sankeyData, countries, totals, leaderBoard } = parseWorld(
         rawData,
         null,
-        GLOBALS.THRESHOLD
+        GLOBALS.THRESHOLD,
+        GLOBALS.US_THRESHOLD
     );
 
     // event handler for dropdown change
@@ -24,10 +26,16 @@ const init = () => {
                 ? null
                 : dropdownEl.value;
 
+        currentThreshold =
+            country === GLOBALS.US_KEY
+                ? GLOBALS.US_THRESHOLD
+                : GLOBALS.THRESHOLD;
+
         const { sankey: sankeyData, leaderBoard } = parseWorld(
             rawData,
             country,
-            GLOBALS.THRESHOLD
+            GLOBALS.THRESHOLD,
+            GLOBALS.US_THRESHOLD
         );
         updateLeaderBoard(leaderBoard);
 
@@ -232,7 +240,8 @@ const updateChart = (graph, node, link, label) => {
                     .text(
                         d =>
                             `${formatNodeLabelLabel(
-                                d.name
+                                d.name,
+                                currentThreshold
                             )}\n${d.value.toLocaleString()}`
                     );
             },
@@ -266,9 +275,11 @@ const updateChart = (graph, node, link, label) => {
                     .text(
                         d =>
                             `${formatNodeLabelLabel(
-                                d.source.name
+                                d.source.name,
+                                currentThreshold
                             )} → ${formatNodeLabelLabel(
-                                d.target.name
+                                d.target.name,
+                                currentThreshold
                             )}\n${d.value.toLocaleString()}`
                     );
             },
@@ -290,7 +301,7 @@ const updateChart = (graph, node, link, label) => {
                     .attr('text-anchor', d =>
                         d.x0 < width / 2 ? 'start' : 'end'
                     )
-                    .text(d => formatNodeLabelLabel(d.name))
+                    .text(d => formatNodeLabelLabel(d.name, currentThreshold))
                     .append('tspan')
                     .attr('fill-opacity', 0.7)
                     .text(d => ` (${d.value.toLocaleString()})`);

--- a/src/index.js
+++ b/src/index.js
@@ -112,12 +112,15 @@ const updateTimestamp = results => {
 
 const formatNodeLabelLabel = (label, threshold = GLOBALS.THRESHOLD) => {
     const formatter = d3.format(',');
+    const mappedLabel = mapLabelName(label);
     const upperFormatter = str => `${str[0].toUpperCase()}${str.slice(1)}`;
 
     return label === 'other'
         ? `< ${formatter(threshold)} cases`
-        : upperFormatter(label);
+        : upperFormatter(mappedLabel);
 };
+
+const mapLabelName = label => GLOBALS.DROPDOWN_MAPPING[label] || label;
 
 const genCountryDropdown = countries => {
     const dropdown = d3.select('#countries');
@@ -127,7 +130,7 @@ const genCountryDropdown = countries => {
         .data(countries)
         .enter()
         .append('option')
-        .text(data => data)
+        .text(data => mapLabelName(data))
         .attr('value', data => data);
 
     return dropdown.node();

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,6 @@ const init = () => {
     };
 
     // configure country dropdown
-    countries.unshift(GLOBALS.ALL_COUNTRIES); // add all countries option
     const dropdownEl = genCountryDropdown(countries);
     dropdownEl.addEventListener('change', onDropdownChange);
 
@@ -124,10 +123,15 @@ const mapLabelName = label => GLOBALS.DROPDOWN_MAPPING[label] || label;
 
 const genCountryDropdown = countries => {
     const dropdown = d3.select('#countries');
+    const filteredCountries = countries.filter(
+        country => country !== GLOBALS.US_KEY
+    );
+    // add all countries and us to the top of the list
+    filteredCountries.unshift(GLOBALS.ALL_COUNTRIES, GLOBALS.US_KEY);
 
     dropdown
         .selectAll('option')
-        .data(countries)
+        .data(filteredCountries)
         .enter()
         .append('option')
         .text(data => mapLabelName(data))

--- a/src/process-data.js
+++ b/src/process-data.js
@@ -17,6 +17,7 @@ const LEADER_BOARD_TITLES = {
 const CASE_TYPES = ['active', 'deaths', 'recovered'];
 
 export const parseWorld = (data, selectedCountry = null, threshold = 5000) => {
+    const { world: worldData, us: usData } = data;
     const totals = {
         confirmed: 0,
         deaths: 0,
@@ -46,12 +47,12 @@ export const parseWorld = (data, selectedCountry = null, threshold = 5000) => {
 
     const links = [];
 
-    const countries = Object.keys(data).sort();
+    const countries = Object.keys(worldData).sort();
 
     const selectedCountries = selectedCountry ? [selectedCountry] : countries;
 
     selectedCountries.forEach(curCountry => {
-        const latestStats = [...data[curCountry]].pop();
+        const latestStats = [...worldData[curCountry]].pop();
 
         Object.keys(totals).forEach(curItemKey => {
             if (!latestStats[curItemKey]) {

--- a/src/process-data.js
+++ b/src/process-data.js
@@ -1,6 +1,8 @@
+import { GLOBALS } from './globals';
+
 // constants
 const NODE_NAMES = {
-    US: 'US',
+    US: GLOBALS.US_KEY,
     OTHER: 'other',
 };
 const NODE_TYPES = {

--- a/src/raw-data.json
+++ b/src/raw-data.json
@@ -1,1402 +1,1878 @@
 {
-  "US": [
-    {
-      "confirmed": 83836,
-      "deaths": 1209,
-      "recovered": 681,
-      "date": "2020-03-26 23:48:35"
-    }
-  ],
-  "Canada": [
-    {
-      "confirmed": 4042,
-      "deaths": 38,
-      "recovered": 184,
-      "date": "2020-03-26 23:53:11"
-    }
-  ],
-  "China": [
-    {
-      "confirmed": 81782,
-      "deaths": 3291,
-      "recovered": 74181,
-      "date": "2020-03-08 05:19:01"
-    }
-  ],
-  "Netherlands": [
-    {
-      "confirmed": 7468,
-      "deaths": 435,
-      "recovered": 6,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Australia": [
-    {
-      "confirmed": 2810,
-      "deaths": 13,
-      "recovered": 172,
-      "date": "2020-03-26 23:53:24"
-    }
-  ],
-  "United Kingdom": [
-    {
-      "confirmed": 11812,
-      "deaths": 580,
-      "recovered": 150,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Denmark": [
-    {
-      "confirmed": 2023,
-      "deaths": 41,
-      "recovered": 50,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "France": [
-    {
-      "confirmed": 29551,
-      "deaths": 1698,
-      "recovered": 4955,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Afghanistan": [
-    {
-      "confirmed": 94,
-      "deaths": 4,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Albania": [
-    {
-      "confirmed": 174,
-      "deaths": 6,
-      "recovered": 17,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Algeria": [
-    {
-      "confirmed": 367,
-      "deaths": 25,
-      "recovered": 29,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Andorra": [
-    {
-      "confirmed": 224,
-      "deaths": 3,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Angola": [
-    {
-      "confirmed": 4,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Antigua and Barbuda": [
-    {
-      "confirmed": 7,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Argentina": [
-    {
-      "confirmed": 502,
-      "deaths": 9,
-      "recovered": 63,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Armenia": [
-    {
-      "confirmed": 290,
-      "deaths": 1,
-      "recovered": 18,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Austria": [
-    {
-      "confirmed": 6909,
-      "deaths": 49,
-      "recovered": 112,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Azerbaijan": [
-    {
-      "confirmed": 122,
-      "deaths": 3,
-      "recovered": 15,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Bahamas": [
-    {
-      "confirmed": 9,
-      "deaths": 0,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Bahrain": [
-    {
-      "confirmed": 458,
-      "deaths": 4,
-      "recovered": 204,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Bangladesh": [
-    {
-      "confirmed": 44,
-      "deaths": 5,
-      "recovered": 11,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Barbados": [
-    {
-      "confirmed": 18,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Belarus": [
-    {
-      "confirmed": 86,
-      "deaths": 0,
-      "recovered": 29,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Belgium": [
-    {
-      "confirmed": 6235,
-      "deaths": 220,
-      "recovered": 675,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Belize": [
-    {
-      "confirmed": 2,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Benin": [
-    {
-      "confirmed": 6,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Bhutan": [
-    {
-      "confirmed": 2,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Bolivia": [
-    {
-      "confirmed": 43,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Bosnia and Herzegovina": [
-    {
-      "confirmed": 191,
-      "deaths": 3,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Brazil": [
-    {
-      "confirmed": 2985,
-      "deaths": 77,
-      "recovered": 6,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Brunei": [
-    {
-      "confirmed": 114,
-      "deaths": 0,
-      "recovered": 5,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Bulgaria": [
-    {
-      "confirmed": 264,
-      "deaths": 3,
-      "recovered": 8,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Burkina Faso": [
-    {
-      "confirmed": 152,
-      "deaths": 7,
-      "recovered": 10,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Cabo Verde": [
-    {
-      "confirmed": 4,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Cambodia": [
-    {
-      "confirmed": 96,
-      "deaths": 0,
-      "recovered": 10,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Cameroon": [
-    {
-      "confirmed": 75,
-      "deaths": 1,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Central African Republic": [
-    {
-      "confirmed": 3,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Chad": [
-    {
-      "confirmed": 3,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Chile": [
-    {
-      "confirmed": 1306,
-      "deaths": 4,
-      "recovered": 22,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Colombia": [
-    {
-      "confirmed": 491,
-      "deaths": 6,
-      "recovered": 8,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Congo (Brazzaville)": [
-    {
-      "confirmed": 4,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Congo (Kinshasa)": [
-    {
-      "confirmed": 51,
-      "deaths": 3,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Costa Rica": [
-    {
-      "confirmed": 231,
-      "deaths": 2,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Cote d'Ivoire": [
-    {
-      "confirmed": 96,
-      "deaths": 0,
-      "recovered": 3,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Croatia": [
-    {
-      "confirmed": 495,
-      "deaths": 3,
-      "recovered": 22,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Cuba": [
-    {
-      "confirmed": 67,
-      "deaths": 2,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Cyprus": [
-    {
-      "confirmed": 146,
-      "deaths": 3,
-      "recovered": 4,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Czechia": [
-    {
-      "confirmed": 1925,
-      "deaths": 9,
-      "recovered": 10,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Diamond Princess": [
-    {
-      "confirmed": 712,
-      "deaths": 10,
-      "recovered": 597,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Djibouti": [
-    {
-      "confirmed": 11,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Dominica": [
-    {
-      "confirmed": 11,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Dominican Republic": [
-    {
-      "confirmed": 488,
-      "deaths": 10,
-      "recovered": 3,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Ecuador": [
-    {
-      "confirmed": 1403,
-      "deaths": 34,
-      "recovered": 3,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Egypt": [
-    {
-      "confirmed": 495,
-      "deaths": 24,
-      "recovered": 102,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "El Salvador": [
-    {
-      "confirmed": 13,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Equatorial Guinea": [
-    {
-      "confirmed": 12,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Eritrea": [
-    {
-      "confirmed": 6,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Estonia": [
-    {
-      "confirmed": 538,
-      "deaths": 1,
-      "recovered": 8,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Eswatini": [
-    {
-      "confirmed": 6,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Ethiopia": [
-    {
-      "confirmed": 12,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Fiji": [
-    {
-      "confirmed": 5,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Finland": [
-    {
-      "confirmed": 958,
-      "deaths": 5,
-      "recovered": 10,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Gabon": [
-    {
-      "confirmed": 7,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Gambia": [
-    {
-      "confirmed": 3,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Georgia": [
-    {
-      "confirmed": 79,
-      "deaths": 0,
-      "recovered": 11,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Germany": [
-    {
-      "confirmed": 43938,
-      "deaths": 267,
-      "recovered": 5673,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Ghana": [
-    {
-      "confirmed": 132,
-      "deaths": 4,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Greece": [
-    {
-      "confirmed": 892,
-      "deaths": 26,
-      "recovered": 36,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Grenada": [
-    {
-      "confirmed": 7,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Guatemala": [
-    {
-      "confirmed": 25,
-      "deaths": 1,
-      "recovered": 4,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Guinea": [
-    {
-      "confirmed": 4,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Guinea-Bissau": [
-    {
-      "confirmed": 2,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Guyana": [
-    {
-      "confirmed": 5,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Haiti": [
-    {
-      "confirmed": 8,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Holy See": [
-    {
-      "confirmed": 4,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Honduras": [
-    {
-      "confirmed": 52,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Hungary": [
-    {
-      "confirmed": 261,
-      "deaths": 10,
-      "recovered": 28,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Iceland": [
-    {
-      "confirmed": 802,
-      "deaths": 2,
-      "recovered": 82,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "India": [
-    {
-      "confirmed": 727,
-      "deaths": 20,
-      "recovered": 45,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Indonesia": [
-    {
-      "confirmed": 893,
-      "deaths": 78,
-      "recovered": 35,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Iran": [
-    {
-      "confirmed": 29406,
-      "deaths": 2234,
-      "recovered": 10457,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Iraq": [
-    {
-      "confirmed": 382,
-      "deaths": 36,
-      "recovered": 105,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Ireland": [
-    {
-      "confirmed": 1819,
-      "deaths": 19,
-      "recovered": 5,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Israel": [
-    {
-      "confirmed": 2693,
-      "deaths": 8,
-      "recovered": 68,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Italy": [
-    {
-      "confirmed": 80589,
-      "deaths": 8215,
-      "recovered": 10361,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Jamaica": [
-    {
-      "confirmed": 26,
-      "deaths": 1,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Japan": [
-    {
-      "confirmed": 1387,
-      "deaths": 47,
-      "recovered": 359,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Jordan": [
-    {
-      "confirmed": 212,
-      "deaths": 0,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Kazakhstan": [
-    {
-      "confirmed": 111,
-      "deaths": 1,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Kenya": [
-    {
-      "confirmed": 31,
-      "deaths": 1,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Korea, South": [
-    {
-      "confirmed": 9241,
-      "deaths": 131,
-      "recovered": 4144,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Kosovo": [
-    {
-      "confirmed": 71,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Kuwait": [
-    {
-      "confirmed": 208,
-      "deaths": 0,
-      "recovered": 49,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Kyrgyzstan": [
-    {
-      "confirmed": 44,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Laos": [
-    {
-      "confirmed": 6,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Latvia": [
-    {
-      "confirmed": 244,
-      "deaths": 0,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Lebanon": [
-    {
-      "confirmed": 368,
-      "deaths": 6,
-      "recovered": 23,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Liberia": [
-    {
-      "confirmed": 3,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Libya": [
-    {
-      "confirmed": 1,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Liechtenstein": [
-    {
-      "confirmed": 56,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Lithuania": [
-    {
-      "confirmed": 299,
-      "deaths": 4,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Luxembourg": [
-    {
-      "confirmed": 1453,
-      "deaths": 9,
-      "recovered": 6,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Madagascar": [
-    {
-      "confirmed": 23,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Malaysia": [
-    {
-      "confirmed": 2031,
-      "deaths": 23,
-      "recovered": 215,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Maldives": [
-    {
-      "confirmed": 13,
-      "deaths": 0,
-      "recovered": 8,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Mali": [
-    {
-      "confirmed": 4,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Malta": [
-    {
-      "confirmed": 134,
-      "deaths": 0,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Mauritania": [
-    {
-      "confirmed": 3,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Mauritius": [
-    {
-      "confirmed": 81,
-      "deaths": 2,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Mexico": [
-    {
-      "confirmed": 475,
-      "deaths": 6,
-      "recovered": 4,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Moldova": [
-    {
-      "confirmed": 177,
-      "deaths": 1,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Monaco": [
-    {
-      "confirmed": 33,
-      "deaths": 0,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Mongolia": [
-    {
-      "confirmed": 11,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Montenegro": [
-    {
-      "confirmed": 69,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Morocco": [
-    {
-      "confirmed": 275,
-      "deaths": 11,
-      "recovered": 8,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Mozambique": [
-    {
-      "confirmed": 7,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Namibia": [
-    {
-      "confirmed": 8,
-      "deaths": 0,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Nepal": [
-    {
-      "confirmed": 3,
-      "deaths": 0,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "New Zealand": [
-    {
-      "confirmed": 283,
-      "deaths": 0,
-      "recovered": 27,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Nicaragua": [
-    {
-      "confirmed": 2,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Niger": [
-    {
-      "confirmed": 10,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Nigeria": [
-    {
-      "confirmed": 65,
-      "deaths": 1,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "North Macedonia": [
-    {
-      "confirmed": 201,
-      "deaths": 3,
-      "recovered": 3,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Norway": [
-    {
-      "confirmed": 3369,
-      "deaths": 14,
-      "recovered": 6,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Oman": [
-    {
-      "confirmed": 109,
-      "deaths": 0,
-      "recovered": 23,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Pakistan": [
-    {
-      "confirmed": 1201,
-      "deaths": 9,
-      "recovered": 21,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Panama": [
-    {
-      "confirmed": 558,
-      "deaths": 8,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Papua New Guinea": [
-    {
-      "confirmed": 1,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Paraguay": [
-    {
-      "confirmed": 41,
-      "deaths": 3,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Peru": [
-    {
-      "confirmed": 580,
-      "deaths": 9,
-      "recovered": 14,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Philippines": [
-    {
-      "confirmed": 707,
-      "deaths": 45,
-      "recovered": 28,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Poland": [
-    {
-      "confirmed": 1221,
-      "deaths": 16,
-      "recovered": 7,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Portugal": [
-    {
-      "confirmed": 3544,
-      "deaths": 60,
-      "recovered": 43,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Qatar": [
-    {
-      "confirmed": 549,
-      "deaths": 0,
-      "recovered": 43,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Romania": [
-    {
-      "confirmed": 1029,
-      "deaths": 23,
-      "recovered": 94,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Russia": [
-    {
-      "confirmed": 840,
-      "deaths": 3,
-      "recovered": 38,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Rwanda": [
-    {
-      "confirmed": 50,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Saint Kitts and Nevis": [
-    {
-      "confirmed": 2,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Saint Lucia": [
-    {
-      "confirmed": 3,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Saint Vincent and the Grenadines": [
-    {
-      "confirmed": 1,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "San Marino": [
-    {
-      "confirmed": 208,
-      "deaths": 21,
-      "recovered": 4,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Saudi Arabia": [
-    {
-      "confirmed": 1012,
-      "deaths": 3,
-      "recovered": 33,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Senegal": [
-    {
-      "confirmed": 105,
-      "deaths": 0,
-      "recovered": 9,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Serbia": [
-    {
-      "confirmed": 384,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Seychelles": [
-    {
-      "confirmed": 7,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Singapore": [
-    {
-      "confirmed": 683,
-      "deaths": 2,
-      "recovered": 172,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Slovakia": [
-    {
-      "confirmed": 226,
-      "deaths": 0,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Slovenia": [
-    {
-      "confirmed": 562,
-      "deaths": 6,
-      "recovered": 10,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Somalia": [
-    {
-      "confirmed": 2,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "South Africa": [
-    {
-      "confirmed": 927,
-      "deaths": 0,
-      "recovered": 12,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Spain": [
-    {
-      "confirmed": 57786,
-      "deaths": 4365,
-      "recovered": 7015,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Sri Lanka": [
-    {
-      "confirmed": 106,
-      "deaths": 0,
-      "recovered": 7,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Sudan": [
-    {
-      "confirmed": 3,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Suriname": [
-    {
-      "confirmed": 8,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Sweden": [
-    {
-      "confirmed": 2840,
-      "deaths": 77,
-      "recovered": 16,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Switzerland": [
-    {
-      "confirmed": 11811,
-      "deaths": 191,
-      "recovered": 131,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Syria": [
-    {
-      "confirmed": 5,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Taiwan*": [
-    {
-      "confirmed": 252,
-      "deaths": 2,
-      "recovered": 29,
-      "date": "2020-03-26 07:31:30"
-    }
-  ],
-  "Tanzania": [
-    {
-      "confirmed": 13,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Thailand": [
-    {
-      "confirmed": 1045,
-      "deaths": 4,
-      "recovered": 88,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Timor-Leste": [
-    {
-      "confirmed": 1,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Togo": [
-    {
-      "confirmed": 23,
-      "deaths": 0,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Trinidad and Tobago": [
-    {
-      "confirmed": 65,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Tunisia": [
-    {
-      "confirmed": 197,
-      "deaths": 6,
-      "recovered": 2,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Turkey": [
-    {
-      "confirmed": 3629,
-      "deaths": 75,
-      "recovered": 26,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Uganda": [
-    {
-      "confirmed": 14,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Ukraine": [
-    {
-      "confirmed": 196,
-      "deaths": 5,
-      "recovered": 1,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "United Arab Emirates": [
-    {
-      "confirmed": 333,
-      "deaths": 2,
-      "recovered": 52,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Uruguay": [
-    {
-      "confirmed": 217,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Uzbekistan": [
-    {
-      "confirmed": 75,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Venezuela": [
-    {
-      "confirmed": 107,
-      "deaths": 0,
-      "recovered": 15,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Vietnam": [
-    {
-      "confirmed": 153,
-      "deaths": 0,
-      "recovered": 20,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "West Bank and Gaza": [
-    {
-      "confirmed": 84,
-      "deaths": 1,
-      "recovered": 17,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Zambia": [
-    {
-      "confirmed": 16,
-      "deaths": 0,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ],
-  "Zimbabwe": [
-    {
-      "confirmed": 3,
-      "deaths": 1,
-      "recovered": 0,
-      "date": "2020-03-26 23:48:18"
-    }
-  ]
+  "world": {
+    "Canada": [
+      {
+        "confirmed": 4042,
+        "deaths": 38,
+        "recovered": 184,
+        "date": "2020-03-26 23:53:11"
+      }
+    ],
+    "US": [
+      {
+        "confirmed": 83836,
+        "deaths": 1209,
+        "recovered": 681,
+        "date": "2020-03-26 23:48:35"
+      }
+    ],
+    "China": [
+      {
+        "confirmed": 81782,
+        "deaths": 3291,
+        "recovered": 74181,
+        "date": "2020-03-08 05:19:01"
+      }
+    ],
+    "Netherlands": [
+      {
+        "confirmed": 7468,
+        "deaths": 435,
+        "recovered": 6,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Australia": [
+      {
+        "confirmed": 2810,
+        "deaths": 13,
+        "recovered": 172,
+        "date": "2020-03-26 23:53:24"
+      }
+    ],
+    "United Kingdom": [
+      {
+        "confirmed": 11812,
+        "deaths": 580,
+        "recovered": 150,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Denmark": [
+      {
+        "confirmed": 2023,
+        "deaths": 41,
+        "recovered": 50,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "France": [
+      {
+        "confirmed": 29551,
+        "deaths": 1698,
+        "recovered": 4955,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Afghanistan": [
+      {
+        "confirmed": 94,
+        "deaths": 4,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Albania": [
+      {
+        "confirmed": 174,
+        "deaths": 6,
+        "recovered": 17,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Algeria": [
+      {
+        "confirmed": 367,
+        "deaths": 25,
+        "recovered": 29,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Andorra": [
+      {
+        "confirmed": 224,
+        "deaths": 3,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Angola": [
+      {
+        "confirmed": 4,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Antigua and Barbuda": [
+      {
+        "confirmed": 7,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Argentina": [
+      {
+        "confirmed": 502,
+        "deaths": 9,
+        "recovered": 63,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Armenia": [
+      {
+        "confirmed": 290,
+        "deaths": 1,
+        "recovered": 18,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Austria": [
+      {
+        "confirmed": 6909,
+        "deaths": 49,
+        "recovered": 112,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Azerbaijan": [
+      {
+        "confirmed": 122,
+        "deaths": 3,
+        "recovered": 15,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Bahamas": [
+      {
+        "confirmed": 9,
+        "deaths": 0,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Bahrain": [
+      {
+        "confirmed": 458,
+        "deaths": 4,
+        "recovered": 204,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Bangladesh": [
+      {
+        "confirmed": 44,
+        "deaths": 5,
+        "recovered": 11,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Barbados": [
+      {
+        "confirmed": 18,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Belarus": [
+      {
+        "confirmed": 86,
+        "deaths": 0,
+        "recovered": 29,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Belgium": [
+      {
+        "confirmed": 6235,
+        "deaths": 220,
+        "recovered": 675,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Belize": [
+      {
+        "confirmed": 2,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Benin": [
+      {
+        "confirmed": 6,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Bhutan": [
+      {
+        "confirmed": 2,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Bolivia": [
+      {
+        "confirmed": 43,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Bosnia and Herzegovina": [
+      {
+        "confirmed": 191,
+        "deaths": 3,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Brazil": [
+      {
+        "confirmed": 2985,
+        "deaths": 77,
+        "recovered": 6,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Brunei": [
+      {
+        "confirmed": 114,
+        "deaths": 0,
+        "recovered": 5,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Bulgaria": [
+      {
+        "confirmed": 264,
+        "deaths": 3,
+        "recovered": 8,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Burkina Faso": [
+      {
+        "confirmed": 152,
+        "deaths": 7,
+        "recovered": 10,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Cabo Verde": [
+      {
+        "confirmed": 4,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Cambodia": [
+      {
+        "confirmed": 96,
+        "deaths": 0,
+        "recovered": 10,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Cameroon": [
+      {
+        "confirmed": 75,
+        "deaths": 1,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Central African Republic": [
+      {
+        "confirmed": 3,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Chad": [
+      {
+        "confirmed": 3,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Chile": [
+      {
+        "confirmed": 1306,
+        "deaths": 4,
+        "recovered": 22,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Colombia": [
+      {
+        "confirmed": 491,
+        "deaths": 6,
+        "recovered": 8,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Congo (Brazzaville)": [
+      {
+        "confirmed": 4,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Congo (Kinshasa)": [
+      {
+        "confirmed": 51,
+        "deaths": 3,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Costa Rica": [
+      {
+        "confirmed": 231,
+        "deaths": 2,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Cote d'Ivoire": [
+      {
+        "confirmed": 96,
+        "deaths": 0,
+        "recovered": 3,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Croatia": [
+      {
+        "confirmed": 495,
+        "deaths": 3,
+        "recovered": 22,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Cuba": [
+      {
+        "confirmed": 67,
+        "deaths": 2,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Cyprus": [
+      {
+        "confirmed": 146,
+        "deaths": 3,
+        "recovered": 4,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Czechia": [
+      {
+        "confirmed": 1925,
+        "deaths": 9,
+        "recovered": 10,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Diamond Princess": [
+      {
+        "confirmed": 712,
+        "deaths": 10,
+        "recovered": 597,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Djibouti": [
+      {
+        "confirmed": 11,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Dominica": [
+      {
+        "confirmed": 11,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Dominican Republic": [
+      {
+        "confirmed": 488,
+        "deaths": 10,
+        "recovered": 3,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Ecuador": [
+      {
+        "confirmed": 1403,
+        "deaths": 34,
+        "recovered": 3,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Egypt": [
+      {
+        "confirmed": 495,
+        "deaths": 24,
+        "recovered": 102,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "El Salvador": [
+      {
+        "confirmed": 13,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Equatorial Guinea": [
+      {
+        "confirmed": 12,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Eritrea": [
+      {
+        "confirmed": 6,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Estonia": [
+      {
+        "confirmed": 538,
+        "deaths": 1,
+        "recovered": 8,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Eswatini": [
+      {
+        "confirmed": 6,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Ethiopia": [
+      {
+        "confirmed": 12,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Fiji": [
+      {
+        "confirmed": 5,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Finland": [
+      {
+        "confirmed": 958,
+        "deaths": 5,
+        "recovered": 10,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Gabon": [
+      {
+        "confirmed": 7,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Gambia": [
+      {
+        "confirmed": 3,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Georgia": [
+      {
+        "confirmed": 79,
+        "deaths": 0,
+        "recovered": 11,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Germany": [
+      {
+        "confirmed": 43938,
+        "deaths": 267,
+        "recovered": 5673,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Ghana": [
+      {
+        "confirmed": 132,
+        "deaths": 4,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Greece": [
+      {
+        "confirmed": 892,
+        "deaths": 26,
+        "recovered": 36,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Grenada": [
+      {
+        "confirmed": 7,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Guatemala": [
+      {
+        "confirmed": 25,
+        "deaths": 1,
+        "recovered": 4,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Guinea": [
+      {
+        "confirmed": 4,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Guinea-Bissau": [
+      {
+        "confirmed": 2,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Guyana": [
+      {
+        "confirmed": 5,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Haiti": [
+      {
+        "confirmed": 8,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Holy See": [
+      {
+        "confirmed": 4,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Honduras": [
+      {
+        "confirmed": 52,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Hungary": [
+      {
+        "confirmed": 261,
+        "deaths": 10,
+        "recovered": 28,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Iceland": [
+      {
+        "confirmed": 802,
+        "deaths": 2,
+        "recovered": 82,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "India": [
+      {
+        "confirmed": 727,
+        "deaths": 20,
+        "recovered": 45,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Indonesia": [
+      {
+        "confirmed": 893,
+        "deaths": 78,
+        "recovered": 35,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Iran": [
+      {
+        "confirmed": 29406,
+        "deaths": 2234,
+        "recovered": 10457,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Iraq": [
+      {
+        "confirmed": 382,
+        "deaths": 36,
+        "recovered": 105,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Ireland": [
+      {
+        "confirmed": 1819,
+        "deaths": 19,
+        "recovered": 5,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Israel": [
+      {
+        "confirmed": 2693,
+        "deaths": 8,
+        "recovered": 68,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Italy": [
+      {
+        "confirmed": 80589,
+        "deaths": 8215,
+        "recovered": 10361,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Jamaica": [
+      {
+        "confirmed": 26,
+        "deaths": 1,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Japan": [
+      {
+        "confirmed": 1387,
+        "deaths": 47,
+        "recovered": 359,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Jordan": [
+      {
+        "confirmed": 212,
+        "deaths": 0,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Kazakhstan": [
+      {
+        "confirmed": 111,
+        "deaths": 1,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Kenya": [
+      {
+        "confirmed": 31,
+        "deaths": 1,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Korea, South": [
+      {
+        "confirmed": 9241,
+        "deaths": 131,
+        "recovered": 4144,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Kosovo": [
+      {
+        "confirmed": 71,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Kuwait": [
+      {
+        "confirmed": 208,
+        "deaths": 0,
+        "recovered": 49,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Kyrgyzstan": [
+      {
+        "confirmed": 44,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Laos": [
+      {
+        "confirmed": 6,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Latvia": [
+      {
+        "confirmed": 244,
+        "deaths": 0,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Lebanon": [
+      {
+        "confirmed": 368,
+        "deaths": 6,
+        "recovered": 23,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Liberia": [
+      {
+        "confirmed": 3,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Libya": [
+      {
+        "confirmed": 1,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Liechtenstein": [
+      {
+        "confirmed": 56,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Lithuania": [
+      {
+        "confirmed": 299,
+        "deaths": 4,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Luxembourg": [
+      {
+        "confirmed": 1453,
+        "deaths": 9,
+        "recovered": 6,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Madagascar": [
+      {
+        "confirmed": 23,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Malaysia": [
+      {
+        "confirmed": 2031,
+        "deaths": 23,
+        "recovered": 215,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Maldives": [
+      {
+        "confirmed": 13,
+        "deaths": 0,
+        "recovered": 8,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Mali": [
+      {
+        "confirmed": 4,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Malta": [
+      {
+        "confirmed": 134,
+        "deaths": 0,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Mauritania": [
+      {
+        "confirmed": 3,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Mauritius": [
+      {
+        "confirmed": 81,
+        "deaths": 2,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Mexico": [
+      {
+        "confirmed": 475,
+        "deaths": 6,
+        "recovered": 4,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Moldova": [
+      {
+        "confirmed": 177,
+        "deaths": 1,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Monaco": [
+      {
+        "confirmed": 33,
+        "deaths": 0,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Mongolia": [
+      {
+        "confirmed": 11,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Montenegro": [
+      {
+        "confirmed": 69,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Morocco": [
+      {
+        "confirmed": 275,
+        "deaths": 11,
+        "recovered": 8,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Mozambique": [
+      {
+        "confirmed": 7,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Namibia": [
+      {
+        "confirmed": 8,
+        "deaths": 0,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Nepal": [
+      {
+        "confirmed": 3,
+        "deaths": 0,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "New Zealand": [
+      {
+        "confirmed": 283,
+        "deaths": 0,
+        "recovered": 27,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Nicaragua": [
+      {
+        "confirmed": 2,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Niger": [
+      {
+        "confirmed": 10,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Nigeria": [
+      {
+        "confirmed": 65,
+        "deaths": 1,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "North Macedonia": [
+      {
+        "confirmed": 201,
+        "deaths": 3,
+        "recovered": 3,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Norway": [
+      {
+        "confirmed": 3369,
+        "deaths": 14,
+        "recovered": 6,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Oman": [
+      {
+        "confirmed": 109,
+        "deaths": 0,
+        "recovered": 23,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Pakistan": [
+      {
+        "confirmed": 1201,
+        "deaths": 9,
+        "recovered": 21,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Panama": [
+      {
+        "confirmed": 558,
+        "deaths": 8,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Papua New Guinea": [
+      {
+        "confirmed": 1,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Paraguay": [
+      {
+        "confirmed": 41,
+        "deaths": 3,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Peru": [
+      {
+        "confirmed": 580,
+        "deaths": 9,
+        "recovered": 14,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Philippines": [
+      {
+        "confirmed": 707,
+        "deaths": 45,
+        "recovered": 28,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Poland": [
+      {
+        "confirmed": 1221,
+        "deaths": 16,
+        "recovered": 7,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Portugal": [
+      {
+        "confirmed": 3544,
+        "deaths": 60,
+        "recovered": 43,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Qatar": [
+      {
+        "confirmed": 549,
+        "deaths": 0,
+        "recovered": 43,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Romania": [
+      {
+        "confirmed": 1029,
+        "deaths": 23,
+        "recovered": 94,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Russia": [
+      {
+        "confirmed": 840,
+        "deaths": 3,
+        "recovered": 38,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Rwanda": [
+      {
+        "confirmed": 50,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Saint Kitts and Nevis": [
+      {
+        "confirmed": 2,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Saint Lucia": [
+      {
+        "confirmed": 3,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Saint Vincent and the Grenadines": [
+      {
+        "confirmed": 1,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "San Marino": [
+      {
+        "confirmed": 208,
+        "deaths": 21,
+        "recovered": 4,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Saudi Arabia": [
+      {
+        "confirmed": 1012,
+        "deaths": 3,
+        "recovered": 33,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Senegal": [
+      {
+        "confirmed": 105,
+        "deaths": 0,
+        "recovered": 9,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Serbia": [
+      {
+        "confirmed": 384,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Seychelles": [
+      {
+        "confirmed": 7,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Singapore": [
+      {
+        "confirmed": 683,
+        "deaths": 2,
+        "recovered": 172,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Slovakia": [
+      {
+        "confirmed": 226,
+        "deaths": 0,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Slovenia": [
+      {
+        "confirmed": 562,
+        "deaths": 6,
+        "recovered": 10,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Somalia": [
+      {
+        "confirmed": 2,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "South Africa": [
+      {
+        "confirmed": 927,
+        "deaths": 0,
+        "recovered": 12,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Spain": [
+      {
+        "confirmed": 57786,
+        "deaths": 4365,
+        "recovered": 7015,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Sri Lanka": [
+      {
+        "confirmed": 106,
+        "deaths": 0,
+        "recovered": 7,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Sudan": [
+      {
+        "confirmed": 3,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Suriname": [
+      {
+        "confirmed": 8,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Sweden": [
+      {
+        "confirmed": 2840,
+        "deaths": 77,
+        "recovered": 16,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Switzerland": [
+      {
+        "confirmed": 11811,
+        "deaths": 191,
+        "recovered": 131,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Syria": [
+      {
+        "confirmed": 5,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Taiwan*": [
+      {
+        "confirmed": 252,
+        "deaths": 2,
+        "recovered": 29,
+        "date": "2020-03-26 07:31:30"
+      }
+    ],
+    "Tanzania": [
+      {
+        "confirmed": 13,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Thailand": [
+      {
+        "confirmed": 1045,
+        "deaths": 4,
+        "recovered": 88,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Timor-Leste": [
+      {
+        "confirmed": 1,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Togo": [
+      {
+        "confirmed": 23,
+        "deaths": 0,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Trinidad and Tobago": [
+      {
+        "confirmed": 65,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Tunisia": [
+      {
+        "confirmed": 197,
+        "deaths": 6,
+        "recovered": 2,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Turkey": [
+      {
+        "confirmed": 3629,
+        "deaths": 75,
+        "recovered": 26,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Uganda": [
+      {
+        "confirmed": 14,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Ukraine": [
+      {
+        "confirmed": 196,
+        "deaths": 5,
+        "recovered": 1,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "United Arab Emirates": [
+      {
+        "confirmed": 333,
+        "deaths": 2,
+        "recovered": 52,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Uruguay": [
+      {
+        "confirmed": 217,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Uzbekistan": [
+      {
+        "confirmed": 75,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Venezuela": [
+      {
+        "confirmed": 107,
+        "deaths": 0,
+        "recovered": 15,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Vietnam": [
+      {
+        "confirmed": 153,
+        "deaths": 0,
+        "recovered": 20,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "West Bank and Gaza": [
+      {
+        "confirmed": 84,
+        "deaths": 1,
+        "recovered": 17,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Zambia": [
+      {
+        "confirmed": 16,
+        "deaths": 0,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ],
+    "Zimbabwe": [
+      {
+        "confirmed": 3,
+        "deaths": 1,
+        "recovered": 0,
+        "date": "2020-03-26 23:48:18"
+      }
+    ]
+  },
+  "us": {
+    "American Samoa": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 0,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "Diamond Princess": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 49,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "Grand Princess": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 28,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ],
+    "Guam": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 45,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ],
+    "Northern Mariana Islands": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 0,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "Puerto Rico": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 64,
+        "deaths": 2,
+        "recovered": 0
+      }
+    ],
+    "Recovered": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 0,
+        "deaths": 0,
+        "recovered": 681
+      }
+    ],
+    "Virgin Islands": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 17,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "South Carolina": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 424,
+        "deaths": 9,
+        "recovered": 0
+      }
+    ],
+    "Louisiana": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 2304,
+        "deaths": 83,
+        "recovered": 0
+      }
+    ],
+    "Virginia": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 466,
+        "deaths": 10,
+        "recovered": 0
+      }
+    ],
+    "Idaho": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 146,
+        "deaths": 3,
+        "recovered": 0
+      }
+    ],
+    "Iowa": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 179,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ],
+    "Kentucky": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 247,
+        "deaths": 5,
+        "recovered": 0
+      }
+    ],
+    "Missouri": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 520,
+        "deaths": 9,
+        "recovered": 0
+      }
+    ],
+    "Oklahoma": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 248,
+        "deaths": 7,
+        "recovered": 0
+      }
+    ],
+    "Colorado": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 1430,
+        "deaths": 19,
+        "recovered": 0
+      }
+    ],
+    "Illinois": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 2538,
+        "deaths": 26,
+        "recovered": 0
+      }
+    ],
+    "Indiana": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 645,
+        "deaths": 17,
+        "recovered": 0
+      }
+    ],
+    "Mississippi": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 485,
+        "deaths": 6,
+        "recovered": 0
+      }
+    ],
+    "Nebraska": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 74,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "North Dakota": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 51,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "Ohio": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 868,
+        "deaths": 15,
+        "recovered": 0
+      }
+    ],
+    "Pennsylvania": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 1795,
+        "deaths": 18,
+        "recovered": 0
+      }
+    ],
+    "Washington": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 3207,
+        "deaths": 150,
+        "recovered": 0
+      }
+    ],
+    "Wisconsin": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 728,
+        "deaths": 10,
+        "recovered": 0
+      }
+    ],
+    "Vermont": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 158,
+        "deaths": 9,
+        "recovered": 0
+      }
+    ],
+    "Minnesota": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 344,
+        "deaths": 2,
+        "recovered": 0
+      }
+    ],
+    "Florida": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 2357,
+        "deaths": 29,
+        "recovered": 0
+      }
+    ],
+    "North Carolina": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 738,
+        "deaths": 3,
+        "recovered": 0
+      }
+    ],
+    "California": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 3899,
+        "deaths": 81,
+        "recovered": 0
+      }
+    ],
+    "New York": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 37877,
+        "deaths": 385,
+        "recovered": 0
+      }
+    ],
+    "Wyoming": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 53,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "Michigan": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 2845,
+        "deaths": 61,
+        "recovered": 0
+      }
+    ],
+    "Alaska": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 56,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ],
+    "Maryland": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 583,
+        "deaths": 4,
+        "recovered": 0
+      }
+    ],
+    "Kansas": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 172,
+        "deaths": 3,
+        "recovered": 0
+      }
+    ],
+    "Tennessee": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 1097,
+        "deaths": 3,
+        "recovered": 0
+      }
+    ],
+    "Texas": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 1563,
+        "deaths": 21,
+        "recovered": 0
+      }
+    ],
+    "Maine": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 155,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "Arizona": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 508,
+        "deaths": 8,
+        "recovered": 0
+      }
+    ],
+    "Georgia": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 1525,
+        "deaths": 48,
+        "recovered": 0
+      }
+    ],
+    "Arkansas": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 335,
+        "deaths": 2,
+        "recovered": 0
+      }
+    ],
+    "New Jersey": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 6876,
+        "deaths": 81,
+        "recovered": 0
+      }
+    ],
+    "South Dakota": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 46,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ],
+    "Alabama": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 517,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ],
+    "Oregon": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 316,
+        "deaths": 11,
+        "recovered": 0
+      }
+    ],
+    "West Virginia": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 52,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "Massachusetts": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 2417,
+        "deaths": 25,
+        "recovered": 0
+      }
+    ],
+    "Utah": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 396,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ],
+    "Montana": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 90,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "New Hampshire": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 137,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ],
+    "New Mexico": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 113,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ],
+    "Rhode Island": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 165,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "Nevada": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 420,
+        "deaths": 10,
+        "recovered": 0
+      }
+    ],
+    "District of Columbia": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 231,
+        "deaths": 3,
+        "recovered": 0
+      }
+    ],
+    "Connecticut": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 1012,
+        "deaths": 21,
+        "recovered": 0
+      }
+    ],
+    "Hawaii": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 95,
+        "deaths": 0,
+        "recovered": 0
+      }
+    ],
+    "Delaware": [
+      {
+        "date": "2020-03-26 23:48:35",
+        "confirmed": 130,
+        "deaths": 1,
+        "recovered": 0
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Fixes #34 
Fixes #41 

Displays US data at a state level vs the country-level for the rest of the world. Expands US to United States and moves the United States to the top of the the Drop down.