### PR TITLE
fix: drops the country/state reference from the label

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -143,14 +143,17 @@
                     <h3>Data Grouping</h3>
                     <p>
                         All countries that have reported less than 5,000 cases
-                        have been grouped in to one category labeled as "< 5,000
-                        cases" to reduce visual noise in the visualization.
+                        have been grouped in to one category labeled as "Other"
+                        to reduce visual noise in the visualization.
                     </p>
                     <p>
                         The United States is further broken down by state and
-                        uses a different threshold for visualization purposes.
-                        The label for the grouped category follows the same
-                        naming convention as with the all countries grouping.
+                        groups the states in the "Other" category using a
+                        different threshold.
+                    </p>
+                    <p>
+                        The specific threshold values are noted in the footnotes
+                        section.
                     </p>
 
                     <h3>Total Confirmed Metric</h3>

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ const updateFootnotes = (country, threshold) => {
     const regionName = country === GLOBALS.US_KEY ? 'states' : 'countries';
     const groupNotes = {
         index: 'other',
-        title: `Other ${regionName}*`,
+        title: `Other*`,
         description: `This category represents all ${regionName} with
 reported cases less than ${formatter(threshold)}`,
     };
@@ -165,9 +165,7 @@ const formatNodeLabelLabel = (label, isUS = false) => {
     const mappedLabel = mapLabelName(label);
     const upperFormatter = str => `${str[0].toUpperCase()}${str.slice(1)}`;
 
-    return label === 'other'
-        ? `Other ${isUS ? 'states' : 'countries'}*`
-        : upperFormatter(mappedLabel);
+    return label === 'other' ? `Other*` : upperFormatter(mappedLabel);
 };
 
 const genCountryDropdown = countries => {
@@ -370,7 +368,8 @@ const updateChart = (graph, node, link, label) => {
                     .attr('text-anchor', d =>
                         d.x0 < width / 2 ? 'start' : 'end'
                     )
-                    .text(d => formatNodeLabelLabel(d.name, isUSSelected))
+                    // TODO: currently, this would overwrite the tspan
+                    //.text(d => formatNodeLabelLabel(d.name, isUSSelected))
                     .select('tspan')
                     .text(d => ` (${d.value.toLocaleString()})`),
             exit => exit.remove()


### PR DESCRIPTION
this is less than ideal, but for the short term this is the route I'm taking. The issue is the tspan appears to get removed on update since it is nested within a text element.

I will like to go back to his problem and address it at a different time.

fixes #67